### PR TITLE
Replace theme toggle emojis with icon components

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { HiMoon, HiSun } from 'react-icons/hi';
 
 export default function ThemeToggle() {
   const [isDark, setIsDark] = useState(() => {
@@ -15,9 +16,20 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={() => setIsDark(!isDark)}
-      className="fixed top-4 right-4 z-50 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-sm rounded-full px-3 py-1 transition-colors"
+      aria-label="Toggle dark mode"
+      className="fixed top-4 right-4 z-50 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-sm rounded-full px-3 py-1 transition-colors flex items-center gap-1"
     >
-      {isDark ? '☀️ Light' : '🌙 Dark'}
+      {isDark ? (
+        <>
+          <HiSun />
+          <span>Light</span>
+        </>
+      ) : (
+        <>
+          <HiMoon />
+          <span>Dark</span>
+        </>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- use `HiSun` and `HiMoon` icons instead of emoji labels for theme toggle
- add `aria-label` for accessibility
- style button as flex container for icon + text

## Testing
- `npm run lint` *(fails: `motion` unused in multiple pages)*

------
https://chatgpt.com/codex/tasks/task_e_68b087c3edd483328a2da432b78bcb8c